### PR TITLE
ignore generated files in source control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /node_modules
 /dist
 .cache
+Generated


### PR DESCRIPTION
The files in `src/Generated` are created by the `npm run build` command, so we don't need to cache them in source control!